### PR TITLE
feature: accept list of paths as pipeline input

### DIFF
--- a/passport_service/core/object_detection.py
+++ b/passport_service/core/object_detection.py
@@ -9,23 +9,29 @@ from io import BytesIO
 from pathlib import Path
 from typing import cast
 
-import Levenshtein as Lev
 import cv2
+import Levenshtein as Lev
 import numpy as np
 import onnxruntime as rt
 import pycountry
-from PIL.Image import fromarray
 from cv2.dnn import NMSBoxes, blobFromImage
 from cv2.typing import MatLike
 from icij_worker.typing_ import RateProgress
 from icij_worker.utils.progress import to_raw_progress
 from onnxruntime import SessionOptions
+from PIL.Image import fromarray
 
-from .mrz import read_passport_file_mrz
-from ..constants import COLOR_LUT, Colorspace, PIL_PNG
-from ..objects import (DetectionRequest, DocPageDetection, MRZ, ObjectDetection,
-                       Passport, PassportDetection)
+from ..constants import COLOR_LUT, PIL_PNG, Colorspace
+from ..objects import (
+    MRZ,
+    DetectionRequest,
+    DocPageDetection,
+    ObjectDetection,
+    Passport,
+    PassportDetection,
+)
 from ..typing_ import BoxLocation, PassportEyeMRZ
+from .mrz import read_passport_file_mrz
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from passport_service.objects import DocMetadata, as_doc_metadata
+from passport_service.objects import (
+    DocMetadata,
+    as_doc_metadata,
+    parse_preprocessing_request,
+)
 from tests import TEST_DATA_DIR
 
 
@@ -21,4 +25,25 @@ def test_as_doc_metadata() -> None:
         DocMetadata(path=Path("passport.png"), extension=".png"),
     ]
 
+    assert doc_metadata == expected
+
+
+def test_parse_preprocessing_request() -> None:
+    # Given
+    data_dir = TEST_DATA_DIR / "passports"
+    docs = [
+        str(data_dir / "some/path/with.ext"),
+        str(data_dir / "some/other_path/with.another_ext"),
+    ]
+
+    # When
+    doc_metadata = parse_preprocessing_request(docs, data_dir=data_dir)
+
+    # Then
+    expected = [
+        DocMetadata(path=Path("some/path/with.ext"), extension=".ext"),
+        DocMetadata(
+            path=Path("some/other_path/with.another_ext"), extension=".another_ext"
+        ),
+    ]
     assert doc_metadata == expected


### PR DESCRIPTION
# Changes
## Added
- added support for documents described as a `list[Path | str]` as pipeline inputs (rather than list of metadata input `list[dict|DocMetadata]` or dir input)